### PR TITLE
Calls to getContentStream fail with exception if self.reload not called first

### DIFF
--- a/src/cmislib/atompub_binding.py
+++ b/src/cmislib/atompub_binding.py
@@ -2463,8 +2463,9 @@ class AtomPubDocument(AtomPubCmisObject):
         The optional streamId argument is not yet supported.
         """
 
-        # TODO: Need to implement the streamId
+        self.reload()
 
+        # TODO: Need to implement the streamId
         contentElements = self.xmlDoc.getElementsByTagNameNS(ATOM_NS, 'content')
 
         assert(len(contentElements) == 1), 'Expected to find exactly one atom:content element.'


### PR DESCRIPTION
Here is the Stackoverflow link that describes the problem I had:

http://stackoverflow.com/questions/15953816/alfresco-document-derived-content-is-missing-content

The one-line fix provided averts the exception.
