### PR TITLE
fix RepositoryService no attribute binding error

### DIFF
--- a/src/cmislib/atompub/binding.py
+++ b/src/cmislib/atompub/binding.py
@@ -252,7 +252,7 @@ class RepositoryService(RepositoryServiceIfc):
         for workspaceElement in workspaceElements:
             idElement = workspaceElement.getElementsByTagNameNS(CMIS_NS, 'repositoryId')
             if idElement[0].childNodes[0].data == repositoryId:
-                return AtomPubRepository(self, workspaceElement)
+                return AtomPubRepository(client, workspaceElement)
 
         raise ObjectNotFoundException(url=client.repositoryUrl)
 


### PR DESCRIPTION
fix *** AttributeError: 'RepositoryService' object has no attribute 'binding' error.

https://stackoverflow.com/questions/47412887/filenet-and-cmislib-attributeerror-repositoryservice-object-has-no-attribute/47430428#47430428